### PR TITLE
Icons, contact form backend, and admin messages inbox

### DIFF
--- a/about.html
+++ b/about.html
@@ -137,6 +137,7 @@
   </footer>
 
   <script src="js/main.js"></script>
+  <script src="js/content-schema.js"></script>
   <script src="js/content-loader.js"></script>
 </body>
 </html>

--- a/admin/contact.html
+++ b/admin/contact.html
@@ -8,43 +8,7 @@
 </head>
 <body>
 <div class="admin-layout">
-
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
-      <div class="sidebar__label">Admin Panel</div>
-    </div>
-    <nav class="sidebar__nav">
-      <div class="sidebar__section-label">Manage</div>
-      <a href="dashboard.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
-        Dashboard
-      </a>
-      <a href="products.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
-        Products
-      </a>
-      <a href="content.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-        Page Content
-      </a>
-      <a href="contact.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
-        Contact Info
-      </a>
-    </nav>
-    <div class="sidebar__footer">
-      <a href="/" target="_blank" class="sidebar__view-site">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-        View live site
-      </a>
-      <button id="logoutBtn" class="sidebar__logout">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
-        Log out
-      </button>
-    </div>
-  </aside>
-
+  <div id="adminSidebar"></div>
   <div class="main">
     <header class="main-header">
       <h1>Contact Info</h1>
@@ -95,15 +59,15 @@
           </div>
         </div>
 
-        <div style="display:flex; justify-content:flex-end;">
+        <div style="display:flex;justify-content:flex-end;">
           <button type="submit" class="btn btn-primary">Save Changes</button>
         </div>
-
       </form>
     </div>
   </div>
 </div>
 <div class="toast"></div>
-<script src="js/admin.js"></script>
+<script src="js/admin-core.js"></script>
+<script src="js/contact-admin.js"></script>
 </body>
 </html>

--- a/admin/content.html
+++ b/admin/content.html
@@ -8,43 +8,7 @@
 </head>
 <body>
 <div class="admin-layout">
-
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
-      <div class="sidebar__label">Admin Panel</div>
-    </div>
-    <nav class="sidebar__nav">
-      <div class="sidebar__section-label">Manage</div>
-      <a href="dashboard.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
-        Dashboard
-      </a>
-      <a href="products.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
-        Products
-      </a>
-      <a href="content.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-        Page Content
-      </a>
-      <a href="contact.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
-        Contact Info
-      </a>
-    </nav>
-    <div class="sidebar__footer">
-      <a href="/" target="_blank" class="sidebar__view-site">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-        View live site
-      </a>
-      <button id="logoutBtn" class="sidebar__logout">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
-        Log out
-      </button>
-    </div>
-  </aside>
-
+  <div id="adminSidebar"></div>
   <div class="main">
     <header class="main-header">
       <h1>Page Content</h1>
@@ -93,15 +57,15 @@
           </div>
         </div>
 
-        <div style="display:flex; justify-content:flex-end;">
+        <div style="display:flex;justify-content:flex-end;">
           <button type="submit" class="btn btn-primary">Save All Changes</button>
         </div>
-
       </form>
     </div>
   </div>
 </div>
 <div class="toast"></div>
-<script src="js/admin.js"></script>
+<script src="js/admin-core.js"></script>
+<script src="js/content-admin.js"></script>
 </body>
 </html>

--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -345,6 +345,19 @@ img { display: block; max-width: 100%; }
 .modal-body { padding: 1.25rem 1.75rem 1.75rem; }
 .modal-footer { display: flex; gap: 0.75rem; justify-content: flex-end; padding-top: 1rem; border-top: 1px solid var(--border); margin-top: 1rem; }
 
+/* Sidebar unread badge */
+.sidebar__badge {
+  margin-left: auto;
+  background: var(--blush);
+  color: var(--white);
+  border-radius: 10px;
+  padding: 1px 7px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  display: none;
+}
+.sidebar__badge:not(:empty) { display: inline; }
+
 /* Image preview in product form */
 .img-preview { width: 100%; aspect-ratio: 4/3; object-fit: cover; border-radius: var(--radius); border: 1px solid var(--border); margin-bottom: 0.75rem; display: none; }
 .img-preview.show { display: block; }

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -8,70 +8,19 @@
 </head>
 <body>
 <div class="admin-layout">
-
-  <!-- Sidebar -->
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
-      <div class="sidebar__label">Admin Panel</div>
-    </div>
-    <nav class="sidebar__nav">
-      <div class="sidebar__section-label">Manage</div>
-      <a href="dashboard.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
-        Dashboard
-      </a>
-      <a href="products.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
-        Products
-      </a>
-      <a href="content.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-        Page Content
-      </a>
-      <a href="contact.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
-        Contact Info
-      </a>
-    </nav>
-    <div class="sidebar__footer">
-      <a href="/" target="_blank" class="sidebar__view-site">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-        View live site
-      </a>
-      <button id="logoutBtn" class="sidebar__logout">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
-        Log out
-      </button>
-    </div>
-  </aside>
-
-  <!-- Main -->
+  <div id="adminSidebar"></div>
   <div class="main">
     <header class="main-header">
       <h1>Dashboard</h1>
     </header>
     <div class="main-body" id="dashStats">
       <div class="stat-grid">
-        <div class="stat-card">
-          <div class="stat-value" id="statTotal">—</div>
-          <div class="stat-label">Total Products</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-value" id="statBouquet">—</div>
-          <div class="stat-label">Bouquets</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-value" id="statWedding">—</div>
-          <div class="stat-label">Wedding</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-value" id="statSeasonal">—</div>
-          <div class="stat-label">Seasonal</div>
-        </div>
+        <div class="stat-card"><div class="stat-value" id="statTotal">—</div><div class="stat-label">Total Products</div></div>
+        <div class="stat-card"><div class="stat-value" id="statBouquet">—</div><div class="stat-label">Bouquets</div></div>
+        <div class="stat-card"><div class="stat-value" id="statWedding">—</div><div class="stat-label">Wedding</div></div>
+        <div class="stat-card"><div class="stat-value" id="statSeasonal">—</div><div class="stat-label">Seasonal</div></div>
       </div>
-
-      <h2 style="font-family: var(--font-serif); font-style: italic; font-weight: 400; margin-bottom: 1.25rem; font-size: 1.1rem;">Quick Actions</h2>
+      <h2 style="font-family:var(--font-serif);font-style:italic;font-weight:400;margin-bottom:1.25rem;font-size:1.1rem;">Quick Actions</h2>
       <div class="quick-links">
         <a href="products.html" class="quick-link">
           <div class="quick-link__icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg></div>
@@ -88,11 +37,17 @@
           <div class="quick-link__title">Update Contact Info</div>
           <div class="quick-link__desc">Change address, phone, email and hours</div>
         </a>
+        <a href="messages.html" class="quick-link">
+          <div class="quick-link__icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg></div>
+          <div class="quick-link__title">View Messages</div>
+          <div class="quick-link__desc">Read and manage customer enquiries</div>
+        </a>
       </div>
     </div>
   </div>
 </div>
 <div class="toast"></div>
-<script src="js/admin.js"></script>
+<script src="js/admin-core.js"></script>
+<script src="js/dashboard-admin.js"></script>
 </body>
 </html>

--- a/admin/js/admin-core.js
+++ b/admin/js/admin-core.js
@@ -1,0 +1,56 @@
+/* ============================================================
+   SYDNEY BLOOMS — Admin Core
+   Auth guard · toast · sidebar · unread badge · API helper
+   ============================================================ */
+
+const $ = id => document.getElementById(id);
+
+const API = (path, opts = {}) =>
+  fetch(`/api${path}`, { headers: { 'Content-Type': 'application/json' }, ...opts })
+    .then(async r => {
+      const json = await r.json();
+      if (!r.ok) throw Object.assign(new Error(json.error || 'Something went wrong'), { status: r.status });
+      return json;
+    });
+
+function toast(msg, type = 'success') {
+  let t = document.querySelector('.toast');
+  if (!t) { t = document.createElement('div'); t.className = 'toast'; document.body.appendChild(t); }
+  t.textContent = msg;
+  t.className = `toast ${type} show`;
+  clearTimeout(t._timer);
+  t._timer = setTimeout(() => t.classList.remove('show'), 3500);
+}
+
+async function loadSidebar() {
+  const placeholder = document.getElementById('adminSidebar');
+  if (!placeholder) return;
+  try {
+    const html = await fetch('/admin/partials/sidebar.html').then(r => r.text());
+    placeholder.outerHTML = html;
+    const page = location.pathname.split('/').pop();
+    document.querySelectorAll('.sidebar__link').forEach(link => {
+      if (link.getAttribute('href') === page) link.classList.add('active');
+    });
+    document.getElementById('logoutBtn')?.addEventListener('click', async () => {
+      await fetch('/api/auth/logout', { method: 'POST' });
+      location.href = '/admin/index.html';
+    });
+  } catch {
+    /* sidebar fails gracefully */
+  }
+}
+
+async function requireAuth() {
+  const res = await fetch('/api/auth/check');
+  if (res.status === 401) { location.href = '/admin/index.html'; return; }
+  loadUnreadCount();
+}
+
+async function loadUnreadCount() {
+  try {
+    const { count } = await API('/messages/unread-count');
+    const badge = document.getElementById('unreadBadge');
+    if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
+  } catch {}
+}

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -21,6 +21,18 @@ function toast(msg, type = 'success') {
 async function requireAuth() {
   const res = await fetch('/api/auth/check');
   if (res.status === 401) { location.href = '/admin/index.html'; }
+  loadUnreadCount();
+}
+
+/* ---- Unread message badge ---- */
+async function loadUnreadCount() {
+  try {
+    const res = await fetch('/api/messages/unread-count');
+    if (!res.ok) return;
+    const { count } = await res.json();
+    const badge = document.getElementById('unreadBadge');
+    if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
+  } catch {}
 }
 
 /* ---- Logout ---- */

--- a/admin/js/contact-admin.js
+++ b/admin/js/contact-admin.js
@@ -1,0 +1,20 @@
+(async () => {
+  await loadSidebar();
+  await requireAuth();
+
+  const info = await API('/contact');
+  Object.entries(info).forEach(([key, value]) => {
+    const el = document.querySelector(`[data-key="${key}"]`);
+    if (el) el.value = value;
+  });
+
+  $('contactForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const body = {};
+    document.querySelectorAll('[data-key]').forEach(el => { body[el.dataset.key] = el.value; });
+    try {
+      await API('/contact', { method: 'PUT', body: JSON.stringify(body) });
+      toast('Contact info saved');
+    } catch { toast('Could not save contact info', 'error'); }
+  });
+})();

--- a/admin/js/content-admin.js
+++ b/admin/js/content-admin.js
@@ -1,0 +1,20 @@
+(async () => {
+  await loadSidebar();
+  await requireAuth();
+
+  const content = await API('/content');
+  Object.entries(content).forEach(([key, value]) => {
+    const el = document.querySelector(`[data-key="${key}"]`);
+    if (el) el.value = value;
+  });
+
+  $('contentForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const body = {};
+    document.querySelectorAll('[data-key]').forEach(el => { body[el.dataset.key] = el.value; });
+    try {
+      await API('/content', { method: 'PUT', body: JSON.stringify(body) });
+      toast('Content saved');
+    } catch { toast('Could not save content', 'error'); }
+  });
+})();

--- a/admin/js/dashboard-admin.js
+++ b/admin/js/dashboard-admin.js
@@ -1,0 +1,10 @@
+(async () => {
+  await loadSidebar();
+  await requireAuth();
+
+  const products = await API('/products');
+  $('statTotal').textContent    = products.length;
+  $('statBouquet').textContent  = products.filter(p => p.category === 'bouquet').length;
+  $('statWedding').textContent  = products.filter(p => p.category === 'wedding').length;
+  $('statSeasonal').textContent = products.filter(p => p.category === 'seasonal').length;
+})();

--- a/admin/js/messages-admin.js
+++ b/admin/js/messages-admin.js
@@ -1,0 +1,96 @@
+let messages = [];
+
+function esc(s) {
+  return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function fmt(dateStr) {
+  return new Date(dateStr).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function updateBadge(count) {
+  const badge = document.getElementById('unreadBadge');
+  if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
+}
+
+function render(msgs) {
+  const tbody = document.getElementById('messagesList');
+  if (!msgs.length) {
+    tbody.innerHTML = `
+      <tr><td colspan="5">
+        <div class="empty-inbox">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
+          <p>No messages yet. Enquiries from your contact form will appear here.</p>
+        </div>
+      </td></tr>`;
+    return;
+  }
+  tbody.innerHTML = msgs.map(m => `
+    <tr class="msg-row ${m.read ? '' : 'unread'}" data-id="${m.id}" onclick="toggleMsg(${m.id})">
+      <td><span class="unread-dot"></span></td>
+      <td>
+        <strong>${esc(m.name)}</strong><br>
+        <span style="font-size:0.82rem;color:var(--muted)">${esc(m.email)}</span>
+      </td>
+      <td>${esc(m.subject || '(no subject)')}</td>
+      <td style="white-space:nowrap">${fmt(m.created_at)}</td>
+      <td class="actions" onclick="event.stopPropagation()">
+        <button class="btn btn-ghost btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
+      </td>
+    </tr>
+    <tr class="msg-expand" id="expand-${m.id}">
+      <td colspan="5">
+        <div class="msg-meta">${m.phone ? 'Phone: ' + esc(m.phone) + ' &nbsp;·&nbsp; ' : ''}Sent ${fmt(m.created_at)}</div>
+        <div class="msg-body">${esc(m.message)}</div>
+        <div class="msg-actions">
+          ${!m.read ? `<button class="btn btn-outline btn-sm" onclick="markRead(${m.id})">Mark as read</button>` : ''}
+          <button class="btn btn-danger btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
+        </div>
+      </td>
+    </tr>
+  `).join('');
+}
+
+window.toggleMsg = async function (id) {
+  const expand = document.getElementById(`expand-${id}`);
+  const isOpen = expand.classList.toggle('open');
+  if (isOpen) {
+    const msg = messages.find(m => m.id === id);
+    if (msg && !msg.read) await markRead(id);
+  }
+};
+
+window.markRead = async function (id) {
+  await fetch(`/api/messages/${id}/read`, { method: 'PUT' });
+  messages = messages.map(m => m.id === id ? { ...m, read: true } : m);
+  render(messages);
+  updateBadge(messages.filter(m => !m.read).length);
+};
+
+window.deleteMsg = async function (id) {
+  if (!confirm('Delete this message? This cannot be undone.')) return;
+  await fetch(`/api/messages/${id}`, { method: 'DELETE' });
+  messages = messages.filter(m => m.id !== id);
+  render(messages);
+  updateBadge(messages.filter(m => !m.read).length);
+  toast('Message deleted');
+};
+
+(async () => {
+  await loadSidebar();
+  await requireAuth();
+
+  const res = await fetch('/api/messages');
+  messages = res.ok ? await res.json() : [];
+  if (!res.ok) toast('Could not load messages', 'error');
+  render(messages);
+  updateBadge(messages.filter(m => !m.read).length);
+
+  document.getElementById('markAllBtn').addEventListener('click', async () => {
+    await fetch('/api/messages/read-all', { method: 'PUT' });
+    messages = messages.map(m => ({ ...m, read: true }));
+    render(messages);
+    updateBadge(0);
+    toast('All messages marked as read');
+  });
+})();

--- a/admin/js/products-admin.js
+++ b/admin/js/products-admin.js
@@ -1,0 +1,105 @@
+let allProducts = [];
+
+async function loadProducts() {
+  allProducts = await API('/products');
+  renderTable();
+}
+
+function renderTable() {
+  const tbody = $('productsTable');
+  if (!allProducts.length) {
+    tbody.innerHTML = '<tr class="empty-row"><td colspan="6">No products yet. Click "Add Product" to create one.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = allProducts.map(p => `
+    <tr>
+      <td><img src="${p.image_path || ''}" alt="${p.name}" class="product-thumb" onerror="this.style.display='none'"></td>
+      <td><strong>${esc(p.name)}</strong></td>
+      <td><span class="badge ${p.category}">${p.category}</span></td>
+      <td>${esc(p.price || '—')}</td>
+      <td>${esc(p.tag || '—')}</td>
+      <td class="actions">
+        <button class="btn btn-outline btn-sm" onclick="openEditModal(${p.id})">Edit</button>
+        <button class="btn btn-danger btn-sm" onclick="deleteProduct(${p.id})">Delete</button>
+      </td>
+    </tr>
+  `).join('');
+}
+
+function esc(s) {
+  return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+window.openAddModal = function () {
+  $('modalTitle').textContent = 'Add Product';
+  $('productForm').reset();
+  $('productId').value = '';
+  $('imagePreview').className = 'img-preview';
+  $('currentImagePath').value = '';
+  openModal();
+};
+
+window.openEditModal = function (id) {
+  const p = allProducts.find(x => x.id === id);
+  if (!p) return;
+  $('modalTitle').textContent       = 'Edit Product';
+  $('productId').value              = id;
+  $('productCategory').value        = p.category;
+  $('productName').value            = p.name;
+  $('productDescription').value     = p.description || '';
+  $('productPrice').value           = p.price || '';
+  $('productTag').value             = p.tag || '';
+  $('productSortOrder').value       = p.sort_order || 0;
+  $('currentImagePath').value       = p.image_path || '';
+  if (p.image_path) {
+    const prev = $('imagePreview');
+    prev.src = p.image_path;
+    prev.className = 'img-preview show';
+  }
+  openModal();
+};
+
+window.deleteProduct = async function (id) {
+  const p = allProducts.find(x => x.id === id);
+  if (!confirm(`Delete "${p?.name}"? This cannot be undone.`)) return;
+  try {
+    await fetch(`/api/products/${id}`, { method: 'DELETE' });
+    toast(`"${p?.name}" deleted`);
+    await loadProducts();
+  } catch { toast('Could not delete product', 'error'); }
+};
+
+function openModal()  { $('productModal').classList.add('open'); document.body.style.overflow = 'hidden'; }
+window.closeModal = function () { $('productModal').classList.remove('open'); document.body.style.overflow = ''; };
+
+$('productForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const id   = $('productId').value;
+  const form = new FormData($('productForm'));
+  try {
+    const res  = await fetch(id ? `/api/products/${id}` : '/api/products', { method: id ? 'PUT' : 'POST', body: form });
+    const json = await res.json();
+    if (json.error) { toast(json.error, 'error'); return; }
+    toast(id ? 'Product updated' : 'Product created');
+    closeModal();
+    await loadProducts();
+  } catch { toast('Could not save product', 'error'); }
+});
+
+$('productImage').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const prev = $('imagePreview');
+  const url  = URL.createObjectURL(file);
+  prev.onload = () => URL.revokeObjectURL(url);
+  prev.src = url;
+  prev.className = 'img-preview show';
+});
+
+$('productModal').addEventListener('click', (e) => { if (e.target === $('productModal')) closeModal(); });
+
+(async () => {
+  await loadSidebar();
+  await requireAuth();
+  await loadProducts();
+})();

--- a/admin/messages.html
+++ b/admin/messages.html
@@ -94,7 +94,9 @@
 <script>
 (async () => {
   await requireAuth();
-  let messages = await fetch('/api/messages').then(r => r.json());
+  const msgsRes = await fetch('/api/messages');
+  let messages = msgsRes.ok ? await msgsRes.json() : [];
+  if (!msgsRes.ok) toast('Could not load messages', 'error');
   render(messages);
 
   document.getElementById('markAllBtn').addEventListener('click', async () => {
@@ -182,7 +184,7 @@
     const badge = document.getElementById('unreadBadge');
     if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
   }
-  updateBadge(msgs => msgs ? msgs.filter(m => !m.read).length : 0);
+  updateBadge(messages.filter(m => !m.read).length);
 })();
 </script>
 </body>

--- a/admin/messages.html
+++ b/admin/messages.html
@@ -17,53 +17,12 @@
     .msg-meta       { font-size: 0.8rem; color: var(--muted); margin-bottom: 1rem; }
     .msg-actions    { display: flex; gap: 0.5rem; }
     .empty-inbox    { text-align: center; padding: 4rem 2rem; color: var(--muted); }
-    .empty-inbox svg { width: 48px; height: 48px; opacity: 0.25; margin: 0 auto 1rem; }
+    .empty-inbox svg { width: 48px; height: 48px; opacity: 0.25; margin: 0 auto 1rem; display: block; }
   </style>
 </head>
 <body>
 <div class="admin-layout">
-
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
-      <div class="sidebar__label">Admin Panel</div>
-    </div>
-    <nav class="sidebar__nav">
-      <div class="sidebar__section-label">Manage</div>
-      <a href="dashboard.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
-        Dashboard
-      </a>
-      <a href="products.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
-        Products
-      </a>
-      <a href="content.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-        Page Content
-      </a>
-      <a href="contact.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
-        Contact Info
-      </a>
-      <a href="messages.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
-        Messages
-        <span class="sidebar__badge" id="unreadBadge"></span>
-      </a>
-    </nav>
-    <div class="sidebar__footer">
-      <a href="/" target="_blank" class="sidebar__view-site">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-        View live site
-      </a>
-      <button id="logoutBtn" class="sidebar__logout">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
-        Log out
-      </button>
-    </div>
-  </aside>
-
+  <div id="adminSidebar"></div>
   <div class="main">
     <header class="main-header">
       <h1>Messages</h1>
@@ -73,13 +32,7 @@
       <div class="table-wrap">
         <table class="table" id="messagesTable">
           <thead>
-            <tr>
-              <th style="width:12px"></th>
-              <th>From</th>
-              <th>Subject</th>
-              <th>Date</th>
-              <th>Actions</th>
-            </tr>
+            <tr><th style="width:12px"></th><th>From</th><th>Subject</th><th>Date</th><th>Actions</th></tr>
           </thead>
           <tbody id="messagesList">
             <tr class="empty-row"><td colspan="5">Loading…</td></tr>
@@ -90,102 +43,7 @@
   </div>
 </div>
 <div class="toast"></div>
-<script src="js/admin.js"></script>
-<script>
-(async () => {
-  await requireAuth();
-  const msgsRes = await fetch('/api/messages');
-  let messages = msgsRes.ok ? await msgsRes.json() : [];
-  if (!msgsRes.ok) toast('Could not load messages', 'error');
-  render(messages);
-
-  document.getElementById('markAllBtn').addEventListener('click', async () => {
-    await fetch('/api/messages/read-all', { method: 'PUT' });
-    messages = messages.map(m => ({ ...m, read: true }));
-    render(messages);
-    updateBadge(0);
-    toast('All messages marked as read');
-  });
-
-  function fmt(dateStr) {
-    return new Date(dateStr).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' });
-  }
-
-  function render(msgs) {
-    const tbody = document.getElementById('messagesList');
-    if (!msgs.length) {
-      tbody.innerHTML = `
-        <tr><td colspan="5">
-          <div class="empty-inbox">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
-            <p>No messages yet. Enquiries from your contact form will appear here.</p>
-          </div>
-        </td></tr>`;
-      return;
-    }
-
-    tbody.innerHTML = msgs.map(m => `
-      <tr class="msg-row ${m.read ? '' : 'unread'}" data-id="${m.id}" onclick="toggleMsg(${m.id})">
-        <td><span class="unread-dot"></span></td>
-        <td>
-          <strong>${esc(m.name)}</strong><br>
-          <span style="font-size:0.82rem;color:var(--muted)">${esc(m.email)}</span>
-        </td>
-        <td>${esc(m.subject || '(no subject)')}</td>
-        <td style="white-space:nowrap">${fmt(m.created_at)}</td>
-        <td class="actions" onclick="event.stopPropagation()">
-          <button class="btn btn-ghost btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
-        </td>
-      </tr>
-      <tr class="msg-expand" id="expand-${m.id}">
-        <td colspan="5">
-          <div class="msg-meta">${m.phone ? 'Phone: ' + esc(m.phone) + ' &nbsp;·&nbsp; ' : ''}Sent ${fmt(m.created_at)}</div>
-          <div class="msg-body">${esc(m.message)}</div>
-          <div class="msg-actions">
-            ${!m.read ? `<button class="btn btn-outline btn-sm" onclick="markRead(${m.id})">Mark as read</button>` : ''}
-            <button class="btn btn-danger btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
-          </div>
-        </td>
-      </tr>
-    `).join('');
-  }
-
-  function esc(s) {
-    if (!s) return '';
-    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  }
-
-  window.toggleMsg = async function(id) {
-    const expand = document.getElementById(`expand-${id}`);
-    const isOpen = expand.classList.toggle('open');
-    if (isOpen) {
-      const msg = messages.find(m => m.id === id);
-      if (msg && !msg.read) await markRead(id);
-    }
-  };
-
-  window.markRead = async function(id) {
-    await fetch(`/api/messages/${id}/read`, { method: 'PUT' });
-    messages = messages.map(m => m.id === id ? { ...m, read: true } : m);
-    render(messages);
-    updateBadge(messages.filter(m => !m.read).length);
-  };
-
-  window.deleteMsg = async function(id) {
-    if (!confirm('Delete this message? This cannot be undone.')) return;
-    await fetch(`/api/messages/${id}`, { method: 'DELETE' });
-    messages = messages.filter(m => m.id !== id);
-    render(messages);
-    updateBadge(messages.filter(m => !m.read).length);
-    toast('Message deleted');
-  };
-
-  function updateBadge(count) {
-    const badge = document.getElementById('unreadBadge');
-    if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
-  }
-  updateBadge(messages.filter(m => !m.read).length);
-})();
-</script>
+<script src="js/admin-core.js"></script>
+<script src="js/messages-admin.js"></script>
 </body>
 </html>

--- a/admin/messages.html
+++ b/admin/messages.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Messages — Sydney Blooms Admin</title>
+  <link rel="stylesheet" href="css/admin.css">
+  <style>
+    .msg-row        { cursor: pointer; }
+    .msg-row.unread td:not(.actions) { font-weight: 700; }
+    .msg-row.unread .unread-dot { display: inline-block; }
+    .unread-dot     { display: none; width: 8px; height: 8px; background: var(--sage); border-radius: 50%; margin-right: 6px; vertical-align: middle; flex-shrink: 0; }
+    .msg-expand     { display: none; background: var(--cream); }
+    .msg-expand.open { display: table-row; }
+    .msg-expand td  { padding: 1.25rem 1.5rem 1.5rem; border-top: none; }
+    .msg-body       { white-space: pre-wrap; font-size: 0.92rem; color: var(--charcoal-mid); line-height: 1.7; margin-bottom: 1rem; }
+    .msg-meta       { font-size: 0.8rem; color: var(--muted); margin-bottom: 1rem; }
+    .msg-actions    { display: flex; gap: 0.5rem; }
+    .empty-inbox    { text-align: center; padding: 4rem 2rem; color: var(--muted); }
+    .empty-inbox svg { width: 48px; height: 48px; opacity: 0.25; margin: 0 auto 1rem; }
+  </style>
+</head>
+<body>
+<div class="admin-layout">
+
+  <aside class="sidebar">
+    <div class="sidebar__brand">
+      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
+      <div class="sidebar__label">Admin Panel</div>
+    </div>
+    <nav class="sidebar__nav">
+      <div class="sidebar__section-label">Manage</div>
+      <a href="dashboard.html" class="sidebar__link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
+        Dashboard
+      </a>
+      <a href="products.html" class="sidebar__link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
+        Products
+      </a>
+      <a href="content.html" class="sidebar__link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+        Page Content
+      </a>
+      <a href="contact.html" class="sidebar__link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
+        Contact Info
+      </a>
+      <a href="messages.html" class="sidebar__link">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
+        Messages
+        <span class="sidebar__badge" id="unreadBadge"></span>
+      </a>
+    </nav>
+    <div class="sidebar__footer">
+      <a href="/" target="_blank" class="sidebar__view-site">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
+        View live site
+      </a>
+      <button id="logoutBtn" class="sidebar__logout">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
+        Log out
+      </button>
+    </div>
+  </aside>
+
+  <div class="main">
+    <header class="main-header">
+      <h1>Messages</h1>
+      <button class="btn btn-outline btn-sm" id="markAllBtn">Mark all as read</button>
+    </header>
+    <div class="main-body">
+      <div class="table-wrap">
+        <table class="table" id="messagesTable">
+          <thead>
+            <tr>
+              <th style="width:12px"></th>
+              <th>From</th>
+              <th>Subject</th>
+              <th>Date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody id="messagesList">
+            <tr class="empty-row"><td colspan="5">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="toast"></div>
+<script src="js/admin.js"></script>
+<script>
+(async () => {
+  await requireAuth();
+  let messages = await fetch('/api/messages').then(r => r.json());
+  render(messages);
+
+  document.getElementById('markAllBtn').addEventListener('click', async () => {
+    await fetch('/api/messages/read-all', { method: 'PUT' });
+    messages = messages.map(m => ({ ...m, read: true }));
+    render(messages);
+    updateBadge(0);
+    toast('All messages marked as read');
+  });
+
+  function fmt(dateStr) {
+    return new Date(dateStr).toLocaleDateString('en-AU', { day: 'numeric', month: 'short', year: 'numeric' });
+  }
+
+  function render(msgs) {
+    const tbody = document.getElementById('messagesList');
+    if (!msgs.length) {
+      tbody.innerHTML = `
+        <tr><td colspan="5">
+          <div class="empty-inbox">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
+            <p>No messages yet. Enquiries from your contact form will appear here.</p>
+          </div>
+        </td></tr>`;
+      return;
+    }
+
+    tbody.innerHTML = msgs.map(m => `
+      <tr class="msg-row ${m.read ? '' : 'unread'}" data-id="${m.id}" onclick="toggleMsg(${m.id})">
+        <td><span class="unread-dot"></span></td>
+        <td>
+          <strong>${esc(m.name)}</strong><br>
+          <span style="font-size:0.82rem;color:var(--muted)">${esc(m.email)}</span>
+        </td>
+        <td>${esc(m.subject || '(no subject)')}</td>
+        <td style="white-space:nowrap">${fmt(m.created_at)}</td>
+        <td class="actions" onclick="event.stopPropagation()">
+          <button class="btn btn-ghost btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
+        </td>
+      </tr>
+      <tr class="msg-expand" id="expand-${m.id}">
+        <td colspan="5">
+          <div class="msg-meta">${m.phone ? 'Phone: ' + esc(m.phone) + ' &nbsp;·&nbsp; ' : ''}Sent ${fmt(m.created_at)}</div>
+          <div class="msg-body">${esc(m.message)}</div>
+          <div class="msg-actions">
+            ${!m.read ? `<button class="btn btn-outline btn-sm" onclick="markRead(${m.id})">Mark as read</button>` : ''}
+            <button class="btn btn-danger btn-sm" onclick="deleteMsg(${m.id})">Delete</button>
+          </div>
+        </td>
+      </tr>
+    `).join('');
+  }
+
+  function esc(s) {
+    if (!s) return '';
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  window.toggleMsg = async function(id) {
+    const expand = document.getElementById(`expand-${id}`);
+    const isOpen = expand.classList.toggle('open');
+    if (isOpen) {
+      const msg = messages.find(m => m.id === id);
+      if (msg && !msg.read) await markRead(id);
+    }
+  };
+
+  window.markRead = async function(id) {
+    await fetch(`/api/messages/${id}/read`, { method: 'PUT' });
+    messages = messages.map(m => m.id === id ? { ...m, read: true } : m);
+    render(messages);
+    updateBadge(messages.filter(m => !m.read).length);
+  };
+
+  window.deleteMsg = async function(id) {
+    if (!confirm('Delete this message? This cannot be undone.')) return;
+    await fetch(`/api/messages/${id}`, { method: 'DELETE' });
+    messages = messages.filter(m => m.id !== id);
+    render(messages);
+    updateBadge(messages.filter(m => !m.read).length);
+    toast('Message deleted');
+  };
+
+  function updateBadge(count) {
+    const badge = document.getElementById('unreadBadge');
+    if (badge) { badge.textContent = count || ''; badge.style.display = count ? 'inline' : 'none'; }
+  }
+  updateBadge(msgs => msgs ? msgs.filter(m => !m.read).length : 0);
+})();
+</script>
+</body>
+</html>

--- a/admin/partials/sidebar.html
+++ b/admin/partials/sidebar.html
@@ -1,0 +1,40 @@
+<aside class="sidebar">
+  <div class="sidebar__brand">
+    <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
+    <div class="sidebar__label">Admin Panel</div>
+  </div>
+  <nav class="sidebar__nav">
+    <div class="sidebar__section-label">Manage</div>
+    <a href="dashboard.html" class="sidebar__link">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
+      Dashboard
+    </a>
+    <a href="products.html" class="sidebar__link">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
+      Products
+    </a>
+    <a href="content.html" class="sidebar__link">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
+      Page Content
+    </a>
+    <a href="contact.html" class="sidebar__link">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
+      Contact Info
+    </a>
+    <a href="messages.html" class="sidebar__link">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>
+      Messages
+      <span class="sidebar__badge" id="unreadBadge"></span>
+    </a>
+  </nav>
+  <div class="sidebar__footer">
+    <a href="/" target="_blank" class="sidebar__view-site">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
+      View live site
+    </a>
+    <button id="logoutBtn" class="sidebar__logout">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
+      Log out
+    </button>
+  </div>
+</aside>

--- a/admin/products.html
+++ b/admin/products.html
@@ -8,43 +8,7 @@
 </head>
 <body>
 <div class="admin-layout">
-
-  <aside class="sidebar">
-    <div class="sidebar__brand">
-      <a href="dashboard.html" class="sidebar__logo">Sydney Blooms</a>
-      <div class="sidebar__label">Admin Panel</div>
-    </div>
-    <nav class="sidebar__nav">
-      <div class="sidebar__section-label">Manage</div>
-      <a href="dashboard.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" /></svg>
-        Dashboard
-      </a>
-      <a href="products.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" /></svg>
-        Products
-      </a>
-      <a href="content.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>
-        Page Content
-      </a>
-      <a href="contact.html" class="sidebar__link">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" /></svg>
-        Contact Info
-      </a>
-    </nav>
-    <div class="sidebar__footer">
-      <a href="/" target="_blank" class="sidebar__view-site">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-        View live site
-      </a>
-      <button id="logoutBtn" class="sidebar__logout">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" /></svg>
-        Log out
-      </button>
-    </div>
-  </aside>
-
+  <div id="adminSidebar"></div>
   <div class="main">
     <header class="main-header">
       <h1>Products</h1>
@@ -57,14 +21,7 @@
       <div class="table-wrap">
         <table class="table">
           <thead>
-            <tr>
-              <th>Image</th>
-              <th>Name</th>
-              <th>Category</th>
-              <th>Price</th>
-              <th>Tag</th>
-              <th>Actions</th>
-            </tr>
+            <tr><th>Image</th><th>Name</th><th>Category</th><th>Price</th><th>Tag</th><th>Actions</th></tr>
           </thead>
           <tbody id="productsTable">
             <tr class="empty-row"><td colspan="6">Loading…</td></tr>
@@ -75,7 +32,6 @@
   </div>
 </div>
 
-<!-- Product Modal -->
 <div class="modal-backdrop" id="productModal">
   <div class="modal">
     <div class="modal-header">
@@ -88,7 +44,6 @@
       <form id="productForm" enctype="multipart/form-data">
         <input type="hidden" id="productId" name="id">
         <input type="hidden" id="currentImagePath" name="image_path">
-
         <div class="form-row">
           <div class="form-group">
             <label class="form-label" for="productCategory">Category</label>
@@ -103,17 +58,14 @@
             <input class="form-input" type="number" id="productSortOrder" name="sort_order" value="1" min="0">
           </div>
         </div>
-
         <div class="form-group">
           <label class="form-label" for="productName">Product Name</label>
           <input class="form-input" type="text" id="productName" name="name" required placeholder="e.g. Classic White Bouquet">
         </div>
-
         <div class="form-group">
           <label class="form-label" for="productDescription">Description</label>
-          <textarea class="form-textarea" id="productDescription" name="description" placeholder="Short description of this arrangement…"></textarea>
+          <textarea class="form-textarea" id="productDescription" name="description" placeholder="Short description…"></textarea>
         </div>
-
         <div class="form-row">
           <div class="form-group">
             <label class="form-label" for="productPrice">Price</label>
@@ -124,14 +76,12 @@
             <input class="form-input" type="text" id="productTag" name="tag" placeholder="e.g. Best Seller">
           </div>
         </div>
-
         <div class="form-group">
           <label class="form-label">Product Image</label>
           <img id="imagePreview" class="img-preview" alt="Preview">
           <input class="form-input" type="file" id="productImage" name="image" accept="image/*">
-          <p style="font-size:0.78rem;color:var(--muted);margin-top:0.4rem;">Upload a new image, or leave blank to keep the current one. Max 5MB.</p>
+          <p style="font-size:0.78rem;color:var(--muted);margin-top:0.4rem;">Max 5MB. Leave blank to keep the current image.</p>
         </div>
-
         <div class="modal-footer">
           <button type="button" class="btn btn-ghost" onclick="closeModal()">Cancel</button>
           <button type="submit" class="btn btn-primary">Save Product</button>
@@ -142,6 +92,7 @@
 </div>
 
 <div class="toast"></div>
-<script src="js/admin.js"></script>
+<script src="js/admin-core.js"></script>
+<script src="js/products-admin.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -109,13 +109,17 @@
         <!-- ===== CONTACT FORM ===== -->
         <section class="form" aria-labelledby="form-heading">
           <h2 id="form-heading" class="form__title reveal"><em>Send us a message</em></h2>
-          <!--
-            UPDATE: To receive emails from this form, either:
-            (a) Change the action to "mailto:your@email.com" — opens user's email client
-            (b) Sign up at formspree.io and replace action with your Formspree endpoint, e.g.:
-                action="https://formspree.io/f/XXXXXXXX" method="POST"
-          -->
-          <form id="contactForm" action="mailto:hello@sydneyblooms.com.au" method="POST" enctype="text/plain" novalidate>
+
+          <!-- Success state -->
+          <div id="formSuccess" role="alert" style="display:none; background:var(--sage-light); border:1px solid var(--sage); border-radius:8px; padding:1.5rem; margin-bottom:1.5rem;">
+            <strong style="color:var(--sage-dark); display:block; margin-bottom:0.4rem;">Message sent!</strong>
+            <span style="font-size:0.92rem; color:var(--charcoal-mid);">Thank you — we'll get back to you within one business day.</span>
+          </div>
+
+          <!-- Error banner -->
+          <div id="formError" role="alert" style="display:none; background:#fdf2f2; border:1px solid #f5c6cb; border-radius:8px; padding:1rem 1.25rem; margin-bottom:1.5rem; font-size:0.9rem; color:#c0392b;"></div>
+
+          <form id="contactForm" novalidate>
 
             <div class="form__group reveal">
               <label class="form__label" for="name">Your Name</label>
@@ -143,7 +147,7 @@
             </div>
 
             <div class="reveal">
-              <button type="submit" class="btn btn--primary btn--lg" style="width: 100%;">Send Message</button>
+              <button type="submit" id="contactSubmit" class="btn btn--primary btn--lg" style="width: 100%;">Send Message</button>
             </div>
 
           </form>

--- a/contact.html
+++ b/contact.html
@@ -191,6 +191,7 @@
   </footer>
 
   <script src="js/main.js"></script>
+  <script src="js/content-schema.js"></script>
   <script src="js/content-loader.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -117,7 +117,7 @@
           </div>
 
           <!-- Error banner -->
-          <div id="formError" role="alert" style="display:none; background:#fdf2f2; border:1px solid #f5c6cb; border-radius:8px; padding:1rem 1.25rem; margin-bottom:1.5rem; font-size:0.9rem; color:#c0392b;"></div>
+          <div id="formError" role="alert" class="form__error" style="display:none;"></div>
 
           <form id="contactForm" novalidate>
 

--- a/css/style.css
+++ b/css/style.css
@@ -293,17 +293,25 @@ p { color: var(--charcoal-mid); }
   transform: translateY(-4px);
 }
 .highlight__icon {
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  height: 72px;
   margin-inline: auto;
   margin-bottom: 1.25rem;
-  background: var(--blush-light);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.highlight__icon svg { width: 30px; height: 30px; color: var(--blush); }
+.highlight__icon svg { width: 34px; height: 34px; }
+
+.highlight__icon--sage  { background: var(--sage-light);  }
+.highlight__icon--sage svg  { color: var(--sage-dark); }
+
+.highlight__icon--green { background: #E8F5E8; }
+.highlight__icon--green svg { color: #4A8F4A; }
+
+.highlight__icon--blush { background: var(--blush-light); }
+.highlight__icon--blush svg { color: var(--blush); }
 .highlight h3 { font-size: 1.1rem; margin-bottom: 0.5rem; }
 .highlight p  { font-size: 0.92rem; color: var(--muted); }
 

--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,11 @@
   --sage-light:   #EEF4EE;
   --blush:        #D4A5A5;
   --blush-light:  #F5E8E8;
+  --green-light:  #E8F5E8;
+  --green-dark:   #4A8F4A;
+  --danger:       #c0392b;
+  --danger-bg:    #fdf2f2;
+  --danger-border:#f5c6cb;
   --charcoal:     #2C2C2C;
   --charcoal-mid: #4A4A4A;
   --muted:        #7A7A7A;
@@ -307,8 +312,8 @@ p { color: var(--charcoal-mid); }
 .highlight__icon--sage  { background: var(--sage-light);  }
 .highlight__icon--sage svg  { color: var(--sage-dark); }
 
-.highlight__icon--green { background: #E8F5E8; }
-.highlight__icon--green svg { color: #4A8F4A; }
+.highlight__icon--green { background: var(--green-light); }
+.highlight__icon--green svg { color: var(--green-dark); }
 
 .highlight__icon--blush { background: var(--blush-light); }
 .highlight__icon--blush svg { color: var(--blush); }
@@ -604,6 +609,17 @@ p { color: var(--charcoal-mid); }
 .reveal-delay-1 { transition-delay: 0.1s; }
 .reveal-delay-2 { transition-delay: 0.2s; }
 .reveal-delay-3 { transition-delay: 0.3s; }
+
+/* ---- Form feedback banners ---- */
+.form__error {
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--danger);
+}
 
 /* ---- Divider ---- */
 .divider {

--- a/index.html
+++ b/index.html
@@ -49,9 +49,10 @@
       <div class="highlights__grid">
 
         <div class="highlight reveal reveal-delay-1">
-          <div class="highlight__icon">
+          <div class="highlight__icon highlight__icon--sage">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 01-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 00-3.213-9.193 2.056 2.056 0 00-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 00-10.026 0 1.106 1.106 0 00-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12" />
+              <!-- Clock: emphasises "same-day" timing -->
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
           <h3>Same-Day Delivery</h3>
@@ -59,9 +60,12 @@
         </div>
 
         <div class="highlight reveal reveal-delay-2">
-          <div class="highlight__icon">
+          <div class="highlight__icon highlight__icon--green">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+              <!-- Leaf: local, natural, seasonal -->
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 2C9 5 5 9 5 14a7 7 0 0014 0C19 9 15 5 12 2z" />
+              <path stroke-linecap="round" d="M12 14L12 21" />
+              <path stroke-linecap="round" d="M12 9L9 13M12 9L15 13" />
             </svg>
           </div>
           <h3>Locally Sourced</h3>
@@ -69,9 +73,10 @@
         </div>
 
         <div class="highlight reveal reveal-delay-3">
-          <div class="highlight__icon">
+          <div class="highlight__icon highlight__icon--blush">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+              <!-- Hand: crafted by hand -->
+              <path stroke-linecap="round" stroke-linejoin="round" d="M10.05 4.575a1.575 1.575 0 10-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 013.15 0v1.5m-3.15 0l.075 5.925m3.075.75V4.575m0 0a1.575 1.575 0 013.15 0V15M6.9 7.575a1.575 1.575 0 10-3.15 0v8.175a6.75 6.75 0 006.75 6.75h2.018a5.25 5.25 0 003.712-1.538l1.732-1.732a5.25 5.25 0 001.538-3.712l-.001-5.925a1.575 1.575 0 00-3.15 0v1.125" />
             </svg>
           </div>
           <h3>Bespoke Arrangements</h3>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
   </footer>
 
   <script src="js/main.js"></script>
+  <script src="js/content-schema.js"></script>
   <script src="js/content-loader.js"></script>
 </body>
 </html>

--- a/js/content-loader.js
+++ b/js/content-loader.js
@@ -1,41 +1,49 @@
 /* ============================================================
    SYDNEY BLOOMS — Dynamic content loader for public pages
+   Keys are authoritative from content-schema.js
    ============================================================ */
 
 async function loadPageContent() {
   try {
     const [content, contact, products] = await Promise.all([
-      fetch('/api/content').then(r => r.json()),
-      fetch('/api/contact').then(r => r.json()),
-      fetch('/api/products').then(r => r.json()),
+      fetch('/api/content').then(r => r.ok ? r.json() : {}),
+      fetch('/api/contact').then(r => r.ok ? r.json() : {}),
+      fetch('/api/products').then(r => r.ok ? r.json() : []),
     ]);
 
-    // Fill elements that have data-content attributes
+    // Merge both stores; contact keys never collide with content keys
+    const all = { ...content, ...contact };
+
     document.querySelectorAll('[data-content]').forEach(el => {
       const key = el.dataset.content;
-      const val = content[key] ?? contact[key];
-      if (val !== undefined) el.textContent = val;
+      const schema = CONTENT_SCHEMA[key] || CONTACT_SCHEMA[key];
+      const val = all[key] ?? schema?.fallback;
+      if (val !== undefined && val !== null) el.textContent = val;
+      else if (schema === undefined) console.warn(`[content-loader] unknown key: "${key}"`);
     });
 
-    // Render product grids if present
     renderProducts(products);
-  } catch {
-    // Server not running — page still renders with fallback HTML
+  } catch (err) {
+    console.error('[content-loader] failed to load:', err);
   }
 }
 
 function makeCard(p, linkHref) {
+  const name  = String(p.name || '').replace(/</g, '&lt;');
+  const desc  = String(p.description || '').replace(/</g, '&lt;');
+  const price = String(p.price || '');
+  const tag   = p.tag ? `<p class="card__tag">${String(p.tag).replace(/</g,'&lt;')}</p>` : '';
   return `
     <article class="card reveal">
       <div class="card__img-wrap">
-        <img src="${p.image_path || ''}" alt="${p.name}" class="card__img" loading="lazy">
+        <img src="${p.image_path || ''}" alt="${name}" class="card__img" loading="lazy">
       </div>
       <div class="card__body">
-        ${p.tag ? `<p class="card__tag">${p.tag}</p>` : ''}
-        <h3 class="card__title">${p.name}</h3>
-        <p class="card__desc">${p.description || ''}</p>
+        ${tag}
+        <h3 class="card__title">${name}</h3>
+        <p class="card__desc">${desc}</p>
         <div class="card__footer">
-          <span class="card__price">${p.price || ''}</span>
+          <span class="card__price">${price}</span>
           <a href="${linkHref}" class="btn btn--outline btn--sm">Enquire</a>
         </div>
       </div>
@@ -43,18 +51,15 @@ function makeCard(p, linkHref) {
 }
 
 function renderProducts(products) {
-  // Home page: one featured card per category
   const featuredGrid = document.getElementById('featuredGrid');
   if (featuredGrid) {
-    const categories = ['bouquet', 'wedding', 'seasonal'];
-    const featured = categories
+    const featured = ['bouquet', 'wedding', 'seasonal']
       .map(cat => products.find(p => p.category === cat))
       .filter(Boolean);
     featuredGrid.innerHTML = featured.map(p => makeCard(p, 'contact.html')).join('');
     observeReveal();
   }
 
-  // Shop page: grouped by category
   ['bouquet', 'wedding', 'seasonal'].forEach(cat => {
     const grid = document.getElementById(`grid-${cat}`);
     if (!grid) return;
@@ -68,7 +73,9 @@ function renderProducts(products) {
 
 function observeReveal() {
   const obs = new IntersectionObserver(
-    entries => entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); } }),
+    entries => entries.forEach(e => {
+      if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); }
+    }),
     { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
   );
   document.querySelectorAll('.reveal:not(.visible)').forEach(el => obs.observe(el));

--- a/js/content-schema.js
+++ b/js/content-schema.js
@@ -1,0 +1,28 @@
+/**
+ * Canonical registry of all editable content keys.
+ * A key not listed here cannot appear in the DB seed, admin form, or content-loader.
+ * Add new keys here first — everything else follows.
+ */
+const CONTENT_SCHEMA = {
+  // Home page — hero
+  hero_eyebrow:   { page: 'home',  label: 'Small label above headline', fallback: 'Welcome to Sydney Blooms' },
+  hero_title:     { page: 'home',  label: 'Main headline',              fallback: 'Fresh. Curated. Delivered.' },
+  hero_subtitle:  { page: 'home',  label: 'Subtitle below headline',    fallback: "Sydney's finest hand-tied bouquets, crafted with love" },
+
+  // About page — story
+  about_eyebrow:  { page: 'about', label: 'Small label above title',    fallback: 'How It Started' },
+  about_title:    { page: 'about', label: 'Story heading',              fallback: "From a kitchen table to Sydney's hearts" },
+  about_para1:    { page: 'about', label: 'Story paragraph 1',          fallback: '' },
+  about_para2:    { page: 'about', label: 'Story paragraph 2',          fallback: '' },
+  about_para3:    { page: 'about', label: 'Story paragraph 3',          fallback: '' },
+};
+
+const CONTACT_SCHEMA = {
+  address_line1:  { label: 'Street address',    fallback: 'Your Street Address' },
+  address_line2:  { label: 'Suburb / postcode', fallback: 'Suburb, Sydney NSW XXXX' },
+  phone:          { label: 'Phone number',      fallback: '(02) XXXX XXXX' },
+  email:          { label: 'Email address',     fallback: 'hello@sydneyblooms.com.au' },
+  hours_weekday:  { label: 'Mon – Fri hours',   fallback: 'Mon – Fri: 8am – 6pm' },
+  hours_saturday: { label: 'Saturday hours',    fallback: 'Saturday: 8am – 4pm' },
+  hours_sunday:   { label: 'Sunday hours',      fallback: 'Sunday: Closed' },
+};

--- a/js/main.js
+++ b/js/main.js
@@ -59,22 +59,63 @@ const revealObserver = new IntersectionObserver(
 );
 document.querySelectorAll('.reveal').forEach(el => revealObserver.observe(el));
 
-/* ---- Contact form: basic client-side validation ---- */
+/* ---- Contact form: submit via API ---- */
 const form = document.getElementById('contactForm');
 if (form) {
-  form.addEventListener('submit', (e) => {
-    let valid = true;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const btn       = document.getElementById('contactSubmit');
+    const errorBox  = document.getElementById('formError');
+    const successBox = document.getElementById('formSuccess');
+
+    // Reset state
+    errorBox.style.display  = 'none';
+    successBox.style.display = 'none';
+    form.querySelectorAll('.form__input, .form__textarea').forEach(f => f.style.borderColor = '');
+
+    // Client-side required check
+    let firstInvalid = null;
     form.querySelectorAll('[required]').forEach(field => {
       if (!field.value.trim()) {
         field.style.borderColor = 'var(--blush)';
-        valid = false;
-      } else {
-        field.style.borderColor = '';
+        firstInvalid = firstInvalid || field;
       }
     });
-    if (!valid) {
-      e.preventDefault();
-      form.querySelector('[required]:invalid, [required]')?.focus();
+    if (firstInvalid) { firstInvalid.focus(); return; }
+
+    // Submit
+    btn.disabled = true;
+    btn.textContent = 'Sending…';
+
+    try {
+      const res  = await fetch('/api/messages', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({
+          name:    form.name.value.trim(),
+          email:   form.email.value.trim(),
+          phone:   form.phone?.value.trim(),
+          subject: form.subject?.value.trim(),
+          message: form.message.value.trim(),
+        }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        form.reset();
+        form.style.display   = 'none';
+        successBox.style.display = 'block';
+        successBox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      } else {
+        errorBox.textContent  = json.error || 'Something went wrong. Please try again.';
+        errorBox.style.display = 'block';
+        btn.disabled   = false;
+        btn.textContent = 'Send Message';
+      }
+    } catch {
+      errorBox.textContent  = 'Could not reach the server. Please try again later.';
+      errorBox.style.display = 'block';
+      btn.disabled   = false;
+      btn.textContent = 'Send Message';
     }
   });
 }

--- a/migrations/002_messages.sql
+++ b/migrations/002_messages.sql
@@ -1,0 +1,12 @@
+-- Contact form enquiries
+
+CREATE TABLE IF NOT EXISTS messages (
+  id         SERIAL PRIMARY KEY,
+  name       VARCHAR(200) NOT NULL,
+  email      VARCHAR(200) NOT NULL,
+  phone      VARCHAR(50),
+  subject    VARCHAR(200),
+  message    TEXT NOT NULL,
+  read       BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP DEFAULT NOW()
+);

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ app.use('/api/auth',     require('./server/routes/auth'));
 app.use('/api/products', require('./server/routes/products'));
 app.use('/api/content',  require('./server/routes/content'));
 app.use('/api/contact',  require('./server/routes/contact'));
+app.use('/api/messages', require('./server/routes/messages'));
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/server/repositories/keyValueRepository.js
+++ b/server/repositories/keyValueRepository.js
@@ -1,0 +1,38 @@
+const db = require('../db');
+
+/**
+ * Returns a repository for any key-value table (site_content, contact_info, etc.).
+ * Callers never write SQL — all query logic lives here.
+ */
+function makeKeyValueRepository(tableName) {
+  async function findAll() {
+    const { rows } = await db.query(`SELECT key, value FROM ${tableName} ORDER BY key`);
+    const result = {};
+    rows.forEach(r => (result[r.key] = r.value));
+    return result;
+  }
+
+  async function upsertMany(entries) {
+    const client = await db.connect();
+    try {
+      await client.query('BEGIN');
+      for (const [key, value] of Object.entries(entries)) {
+        await client.query(
+          `INSERT INTO ${tableName} (key,value) VALUES ($1,$2)
+           ON CONFLICT (key) DO UPDATE SET value=$2, updated_at=NOW()`,
+          [key, value]
+        );
+      }
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  return { findAll, upsertMany };
+}
+
+module.exports = makeKeyValueRepository;

--- a/server/repositories/messageRepository.js
+++ b/server/repositories/messageRepository.js
@@ -1,0 +1,48 @@
+const db = require('../db');
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validate({ name, email, message }) {
+  if (!name?.trim() || !email?.trim() || !message?.trim()) {
+    const err = new Error('Name, email and message are required.');
+    err.status = 422;
+    throw err;
+  }
+  if (!EMAIL_RE.test(email)) {
+    const err = new Error('Please enter a valid email address.');
+    err.status = 422;
+    throw err;
+  }
+}
+
+async function create({ name, email, phone, subject, message }) {
+  validate({ name, email, message });
+  await db.query(
+    'INSERT INTO messages (name,email,phone,subject,message) VALUES ($1,$2,$3,$4,$5)',
+    [name.trim(), email.trim(), phone?.trim() || null, subject?.trim() || null, message.trim()]
+  );
+}
+
+async function findAll() {
+  const { rows } = await db.query('SELECT * FROM messages ORDER BY created_at DESC');
+  return rows;
+}
+
+async function unreadCount() {
+  const { rows } = await db.query('SELECT COUNT(*) AS count FROM messages WHERE read = false');
+  return parseInt(rows[0].count, 10);
+}
+
+async function markRead(id) {
+  await db.query('UPDATE messages SET read = true WHERE id = $1', [id]);
+}
+
+async function markAllRead() {
+  await db.query('UPDATE messages SET read = true');
+}
+
+async function remove(id) {
+  await db.query('DELETE FROM messages WHERE id = $1', [id]);
+}
+
+module.exports = { create, findAll, unreadCount, markRead, markAllRead, remove };

--- a/server/repositories/productRepository.js
+++ b/server/repositories/productRepository.js
@@ -1,0 +1,42 @@
+const db = require('../db');
+
+const ALLOWED_CATEGORIES = ['bouquet', 'wedding', 'seasonal'];
+
+async function findAll({ category } = {}) {
+  if (category) {
+    if (!ALLOWED_CATEGORIES.includes(category)) {
+      const err = new Error('Invalid category');
+      err.status = 400;
+      throw err;
+    }
+    const { rows } = await db.query(
+      'SELECT * FROM products WHERE category=$1 ORDER BY sort_order, id',
+      [category]
+    );
+    return rows;
+  }
+  const { rows } = await db.query('SELECT * FROM products ORDER BY category, sort_order, id');
+  return rows;
+}
+
+async function create({ category, name, description, price, tag, image_path, sort_order }) {
+  const { rows } = await db.query(
+    'INSERT INTO products (category,name,description,price,tag,image_path,sort_order) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *',
+    [category, name, description, price, tag, image_path, sort_order || 0]
+  );
+  return rows[0];
+}
+
+async function update(id, { category, name, description, price, tag, image_path, sort_order }) {
+  const { rows } = await db.query(
+    'UPDATE products SET category=$1,name=$2,description=$3,price=$4,tag=$5,image_path=$6,sort_order=$7 WHERE id=$8 RETURNING *',
+    [category, name, description, price, tag, image_path, sort_order || 0, id]
+  );
+  return rows[0] || null;
+}
+
+async function remove(id) {
+  await db.query('DELETE FROM products WHERE id=$1', [id]);
+}
+
+module.exports = { findAll, create, update, remove, ALLOWED_CATEGORIES };

--- a/server/routes/contact.js
+++ b/server/routes/contact.js
@@ -1,38 +1,17 @@
 const router      = require('express').Router();
-const db          = require('../db');
 const requireAuth = require('../middleware/requireAuth');
+const makeStore   = require('../repositories/keyValueRepository');
 
-// Public: get all contact info as { key: value }
+const store = makeStore('contact_info');
+
 router.get('/', async (req, res) => {
-  try {
-    const result = await db.query('SELECT key, value FROM contact_info ORDER BY key');
-    const info = {};
-    result.rows.forEach(r => (info[r.key] = r.value));
-    res.json(info);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  try   { res.json(await store.findAll()); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: bulk update all contact fields
 router.put('/', requireAuth, async (req, res) => {
-  const client = await db.connect();
-  try {
-    await client.query('BEGIN');
-    for (const [key, value] of Object.entries(req.body)) {
-      await client.query(
-        'INSERT INTO contact_info (key,value) VALUES ($1,$2) ON CONFLICT (key) DO UPDATE SET value=$2, updated_at=NOW()',
-        [key, value]
-      );
-    }
-    await client.query('COMMIT');
-    res.json({ ok: true });
-  } catch (e) {
-    await client.query('ROLLBACK');
-    res.status(500).json({ error: e.message });
-  } finally {
-    client.release();
-  }
+  try   { await store.upsertMany(req.body); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
 module.exports = router;

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -1,52 +1,22 @@
 const router      = require('express').Router();
-const db          = require('../db');
 const requireAuth = require('../middleware/requireAuth');
+const makeStore   = require('../repositories/keyValueRepository');
 
-// Public: get all site content as { key: value }
+const store = makeStore('site_content');
+
 router.get('/', async (req, res) => {
-  try {
-    const result = await db.query('SELECT key, value FROM site_content ORDER BY key');
-    const content = {};
-    result.rows.forEach(r => (content[r.key] = r.value));
-    res.json(content);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  try   { res.json(await store.findAll()); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: upsert a single key
 router.put('/:key', requireAuth, async (req, res) => {
-  try {
-    const { value } = req.body;
-    await db.query(
-      'INSERT INTO site_content (key,value) VALUES ($1,$2) ON CONFLICT (key) DO UPDATE SET value=$2, updated_at=NOW()',
-      [req.params.key, value]
-    );
-    res.json({ ok: true });
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  try   { await store.upsertMany({ [req.params.key]: req.body.value }); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: bulk update multiple keys at once
 router.put('/', requireAuth, async (req, res) => {
-  const client = await db.connect();
-  try {
-    await client.query('BEGIN');
-    for (const [key, value] of Object.entries(req.body)) {
-      await client.query(
-        'INSERT INTO site_content (key,value) VALUES ($1,$2) ON CONFLICT (key) DO UPDATE SET value=$2, updated_at=NOW()',
-        [key, value]
-      );
-    }
-    await client.query('COMMIT');
-    res.json({ ok: true });
-  } catch (e) {
-    await client.query('ROLLBACK');
-    res.status(500).json({ error: e.message });
-  } finally {
-    client.release();
-  }
+  try   { await store.upsertMany(req.body); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
 module.exports = router;

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -1,0 +1,77 @@
+const router      = require('express').Router();
+const db          = require('../db');
+const requireAuth = require('../middleware/requireAuth');
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Public: submit contact form
+router.post('/', async (req, res) => {
+  const { name, email, phone, subject, message } = req.body;
+  if (!name?.trim() || !email?.trim() || !message?.trim()) {
+    return res.status(422).json({ error: 'Name, email and message are required.' });
+  }
+  if (!EMAIL_RE.test(email)) {
+    return res.status(422).json({ error: 'Please enter a valid email address.' });
+  }
+  try {
+    await db.query(
+      'INSERT INTO messages (name,email,phone,subject,message) VALUES ($1,$2,$3,$4,$5)',
+      [name.trim(), email.trim(), phone?.trim() || null, subject?.trim() || null, message.trim()]
+    );
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'Something went wrong. Please try again.' });
+  }
+});
+
+// Admin: unread count — must be before /:id routes
+router.get('/unread-count', requireAuth, async (req, res) => {
+  try {
+    const result = await db.query("SELECT COUNT(*) AS count FROM messages WHERE read = false");
+    res.json({ count: parseInt(result.rows[0].count, 10) });
+  } catch {
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+// Admin: list all messages
+router.get('/', requireAuth, async (req, res) => {
+  try {
+    const result = await db.query('SELECT * FROM messages ORDER BY created_at DESC');
+    res.json(result.rows);
+  } catch {
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+// Admin: mark all as read
+router.put('/read-all', requireAuth, async (req, res) => {
+  try {
+    await db.query('UPDATE messages SET read = true');
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+// Admin: mark one as read
+router.put('/:id/read', requireAuth, async (req, res) => {
+  try {
+    await db.query('UPDATE messages SET read = true WHERE id = $1', [req.params.id]);
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+// Admin: delete message
+router.delete('/:id', requireAuth, async (req, res) => {
+  try {
+    await db.query('DELETE FROM messages WHERE id = $1', [req.params.id]);
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'Something went wrong' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -1,77 +1,40 @@
 const router      = require('express').Router();
-const db          = require('../db');
 const requireAuth = require('../middleware/requireAuth');
+const messages    = require('../repositories/messageRepository');
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-// Public: submit contact form
 router.post('/', async (req, res) => {
-  const { name, email, phone, subject, message } = req.body;
-  if (!name?.trim() || !email?.trim() || !message?.trim()) {
-    return res.status(422).json({ error: 'Name, email and message are required.' });
-  }
-  if (!EMAIL_RE.test(email)) {
-    return res.status(422).json({ error: 'Please enter a valid email address.' });
-  }
   try {
-    await db.query(
-      'INSERT INTO messages (name,email,phone,subject,message) VALUES ($1,$2,$3,$4,$5)',
-      [name.trim(), email.trim(), phone?.trim() || null, subject?.trim() || null, message.trim()]
-    );
+    await messages.create(req.body);
     res.json({ ok: true });
-  } catch {
-    res.status(500).json({ error: 'Something went wrong. Please try again.' });
+  } catch (e) {
+    const status = e.status || 500;
+    res.status(status).json({ error: status === 422 ? e.message : 'Something went wrong. Please try again.' });
   }
 });
 
-// Admin: unread count — must be before /:id routes
 router.get('/unread-count', requireAuth, async (req, res) => {
-  try {
-    const result = await db.query("SELECT COUNT(*) AS count FROM messages WHERE read = false");
-    res.json({ count: parseInt(result.rows[0].count, 10) });
-  } catch {
-    res.status(500).json({ error: 'Something went wrong' });
-  }
+  try   { res.json({ count: await messages.unreadCount() }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: list all messages
 router.get('/', requireAuth, async (req, res) => {
-  try {
-    const result = await db.query('SELECT * FROM messages ORDER BY created_at DESC');
-    res.json(result.rows);
-  } catch {
-    res.status(500).json({ error: 'Something went wrong' });
-  }
+  try   { res.json(await messages.findAll()); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: mark all as read
 router.put('/read-all', requireAuth, async (req, res) => {
-  try {
-    await db.query('UPDATE messages SET read = true');
-    res.json({ ok: true });
-  } catch {
-    res.status(500).json({ error: 'Something went wrong' });
-  }
+  try   { await messages.markAllRead(); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: mark one as read
 router.put('/:id/read', requireAuth, async (req, res) => {
-  try {
-    await db.query('UPDATE messages SET read = true WHERE id = $1', [req.params.id]);
-    res.json({ ok: true });
-  } catch {
-    res.status(500).json({ error: 'Something went wrong' });
-  }
+  try   { await messages.markRead(req.params.id); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: delete message
 router.delete('/:id', requireAuth, async (req, res) => {
-  try {
-    await db.query('DELETE FROM messages WHERE id = $1', [req.params.id]);
-    res.json({ ok: true });
-  } catch {
-    res.status(500).json({ error: 'Something went wrong' });
-  }
+  try   { await messages.remove(req.params.id); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
 module.exports = router;

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,8 +1,8 @@
 const router      = require('express').Router();
 const path        = require('path');
 const multer      = require('multer');
-const db          = require('../db');
 const requireAuth = require('../middleware/requireAuth');
+const products    = require('../repositories/productRepository');
 
 const upload = multer({
   storage: multer.diskStorage({
@@ -11,64 +11,40 @@ const upload = multer({
   }),
   limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
-    if (!file.mimetype.startsWith('image/')) return cb(new Error('Images only'));
-    cb(null, true);
+    const okMime = file.mimetype.startsWith('image/');
+    const okExt  = /\.(jpe?g|png|webp|gif)$/i.test(file.originalname);
+    okMime && okExt ? cb(null, true) : cb(new Error('Images only (jpeg/png/webp/gif)'));
   },
 });
 
-// Public
 router.get('/', async (req, res) => {
   try {
-    const { category } = req.query;
-    const q = category
-      ? 'SELECT * FROM products WHERE category=$1 ORDER BY sort_order, id'
-      : 'SELECT * FROM products ORDER BY category, sort_order, id';
-    const result = category ? await db.query(q, [category]) : await db.query(q);
-    res.json(result.rows);
+    res.json(await products.findAll({ category: req.query.category }));
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    const status = e.status || 500;
+    res.status(status).json({ error: status === 400 ? e.message : 'Something went wrong' });
   }
 });
 
-// Admin: create
 router.post('/', requireAuth, upload.single('image'), async (req, res) => {
   try {
-    const { category, name, description, price, tag, sort_order, image_path } = req.body;
-    const imgPath = req.file ? `/images/${req.file.filename}` : image_path;
-    const result = await db.query(
-      'INSERT INTO products (category,name,description,price,tag,image_path,sort_order) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *',
-      [category, name, description, price, tag, imgPath, sort_order || 0]
-    );
-    res.json(result.rows[0]);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+    const imgPath = req.file ? `/images/${req.file.filename}` : req.body.image_path;
+    res.json(await products.create({ ...req.body, image_path: imgPath }));
+  } catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: update
 router.put('/:id', requireAuth, upload.single('image'), async (req, res) => {
   try {
-    const { category, name, description, price, tag, sort_order, image_path } = req.body;
-    const imgPath = req.file ? `/images/${req.file.filename}` : image_path;
-    const result = await db.query(
-      'UPDATE products SET category=$1,name=$2,description=$3,price=$4,tag=$5,image_path=$6,sort_order=$7 WHERE id=$8 RETURNING *',
-      [category, name, description, price, tag, imgPath, sort_order || 0, req.params.id]
-    );
-    if (!result.rows.length) return res.status(404).json({ error: 'Not found' });
-    res.json(result.rows[0]);
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+    const imgPath = req.file ? `/images/${req.file.filename}` : req.body.image_path;
+    const row = await products.update(req.params.id, { ...req.body, image_path: imgPath });
+    if (!row) return res.status(404).json({ error: 'Not found' });
+    res.json(row);
+  } catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
-// Admin: delete
 router.delete('/:id', requireAuth, async (req, res) => {
-  try {
-    await db.query('DELETE FROM products WHERE id=$1', [req.params.id]);
-    res.json({ ok: true });
-  } catch (e) {
-    res.status(500).json({ error: e.message });
-  }
+  try   { await products.remove(req.params.id); res.json({ ok: true }); }
+  catch { res.status(500).json({ error: 'Something went wrong' }); }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary

- Replaces highlights strip icons with more thematic ones (clock, leaf, hand)
- Connects contact form to server — enquiries saved to PostgreSQL, no more mailto:
- Adds admin Messages inbox with unread count badge in sidebar

## Changes

- `index.html` + `css/style.css` — new icon set with per-icon colour circles
- `contact.html` + `js/main.js` — fetch-based form submission with success/error states
- `server/routes/messages.js` — new API: submit, list, mark-read, delete
- `migrations/002_messages.sql` — new messages table
- `admin/messages.html` — inbox with expand-in-place, mark-read, delete
- All admin sidebars updated with Messages link + unread badge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)